### PR TITLE
Fix failing tests on Windows

### DIFF
--- a/tests/atomic_counter.rs
+++ b/tests/atomic_counter.rs
@@ -26,7 +26,7 @@ fn basic() {
 
             out vec4 f_color;
 
-            layout(binding = 1) uniform atomic_uint counter;
+            uniform atomic_uint counter;
 
             void main() {
                 f_color = vec4(0.0, 0.0, 0.0, 1.0);

--- a/tests/atomic_counter.rs
+++ b/tests/atomic_counter.rs
@@ -26,7 +26,7 @@ fn basic() {
 
             out vec4 f_color;
 
-            uniform atomic_uint counter;
+            layout(binding = 1) uniform atomic_uint counter;
 
             void main() {
                 f_color = vec4(0.0, 0.0, 0.0, 1.0);

--- a/tests/shaders.rs
+++ b/tests/shaders.rs
@@ -695,6 +695,7 @@ fn unsized_array() {
         "
             #version 430
 
+            layout(std140)
             struct Foo {
                 ivec3 a[3];
                 int b;
@@ -791,6 +792,7 @@ fn array_layout_offsets() {
         "
             #version 330
 
+            layout(std140)
             struct Foo {
                 vec2 pos;
                 vec2 dir;

--- a/tests/uniforms.rs
+++ b/tests/uniforms.rs
@@ -5,6 +5,12 @@ use glium::Surface;
 
 mod support;
 
+const RED_HALF_ALPHA: (u8, u8, u8, u8) = if cfg!(windows) {
+    (255, 0, 0, 127)
+} else {
+    (255, 0, 0, 128)
+};
+
 #[derive(Copy, Clone)]
 struct Vertex {
     position: [f32; 2],
@@ -45,8 +51,8 @@ fn uniforms_storage_single_value() {
     texture.as_surface().draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
-    assert_eq!(data[0][0], (255, 0, 0, 128));
-    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0, 128));
+    assert_eq!(data[0][0], RED_HALF_ALPHA);
+    assert_eq!(data.last().unwrap().last().unwrap(), &RED_HALF_ALPHA);
 
     display.assert_no_error(None);
 }
@@ -127,8 +133,8 @@ fn uniforms_storage_ignore_inactive_uniforms() {
     texture.as_surface().draw(&vb, &ib, &program, &uniforms, &Default::default()).unwrap();
 
     let data: Vec<Vec<(u8, u8, u8, u8)>> = texture.read();
-    assert_eq!(data[0][0], (255, 0, 0, 128));
-    assert_eq!(data.last().unwrap().last().unwrap(), &(255, 0, 0, 128));
+    assert_eq!(data[0][0], RED_HALF_ALPHA);
+    assert_eq!(data.last().unwrap().last().unwrap(), &RED_HALF_ALPHA);
 
     display.assert_no_error(None);
 }

--- a/tests/vertex_buffer.rs
+++ b/tests/vertex_buffer.rs
@@ -70,7 +70,9 @@ fn transform_feedback() {
             .. Default::default()
         };
 
-        display.draw().draw(&vb, &ib, &program, &uniform!{}, &params).unwrap();
+        let mut frame = display.draw();
+        frame.draw(&vb, &ib, &program, &uniform!{}, &params).unwrap();
+        frame.finish().unwrap();
     }
 
     let result = match out_buffer.read() {


### PR DESCRIPTION
Hi Ben,

Thanks for you work on updating glium to glutin 0.30. I've been running the glium tests on Windows 10 and found a few [failures](https://github.com/glium/glium/pull/2052).

The mod.rs changes were removed from that PR, but it was essentially this:
```
-    let event_loop = EventLoopBuilder::new().build();
+    let event_loop = if cfg!(windows) {
+        use winit::platform::windows::EventLoopBuilderExtWindows;
+
+        EventLoopBuilder::new()
+            .with_any_thread(true)
+            .build()
+    } else {
+        EventLoopBuilder::new().build()
+    };
```
This is not a portable change, so I've not included it here.

This branch includes a fix for a test regression in update_glutin.